### PR TITLE
New feature: Set PAM service name in sshd_config file

### DIFF
--- a/servconf.h
+++ b/servconf.h
@@ -183,6 +183,8 @@ typedef struct {
 	char   *adm_forced_command;
 
 	int	use_pam;		/* Enable auth via PAM */
+	char   *pam_service_name;
+	char   *password_pam_service_name;
 
 	int	permit_tun;
 

--- a/sshd_config.5
+++ b/sshd_config.5
@@ -1137,7 +1137,9 @@ Available keywords are
 .Cm LogLevel ,
 .Cm MaxAuthTries ,
 .Cm MaxSessions ,
+.Cm PAMServiceName ,
 .Cm PasswordAuthentication ,
+.Cm PasswordPAMServiceName ,
 .Cm PermitEmptyPasswords ,
 .Cm PermitListen ,
 .Cm PermitOpen ,
@@ -1191,10 +1193,57 @@ will refuse connection attempts with a probability of rate/100 (30%)
 if there are currently start (10) unauthenticated connections.
 The probability increases linearly and all connection attempts
 are refused if the number of unauthenticated connections reaches full (60).
+.It Cm PAMServiceName
+Specifies the service identifier to be used for pluggable authentication
+modules (PAM).
+If set to
+.Cm none ,
+the sshd executable name (usually sshd) is used.
+If set to
+.Ar name ,
+authentication options can be configured in a matching file in
+.Ar /etc/pam.d/name .
+The default is
+.Cm none .
 .It Cm PasswordAuthentication
 Specifies whether password authentication is allowed.
 The default is
 .Cm yes .
+.It Cm PasswordPAMServiceName
+Specifies the service identifier to be used for pluggable authentication
+modules (PAM) for
+.Cm PasswordAuthentication
+only. This is only used for the authentication (auth) PAM aspect. For account and
+session management, as well as
+.Cm ChallengeResponseAuthentication ,
+the service name set in
+.Cm PAMServiceName
+is applied. This can be helpful to implement 2 factor authentication.
+Example:
+.Pp
+.Bl -item -offset indent -compact
+.It
+.Cm AuthenticationMethods
+.Qq publickey,keyboard-interactive password,keyboard-interactive
+.It
+.Cm PAMServiceName
+sshd_2factor
+.It
+.Cm PasswordPAMServiceName
+sshd_password
+.El
+.Pp
+In this example, the challenge response authentication would ask the user for
+the second factor, for example an OATH token, while the first factor could be
+either provided by ssh-key or password. This requires two different PAM
+configurations to be used, in this example /etc/pam.d/sshd_2factor and
+/etc/pam.d/sshd_password. If set to
+.Cm none ,
+the value of
+.Cm PAMServiceName
+is used.
+The default is
+.Cm none .
 .It Cm PermitEmptyPasswords
 When password authentication is allowed, it specifies whether the
 server allows login to accounts with empty password strings.


### PR DESCRIPTION
This allows different pam auth configurations based on
used AuthenticationMethod and Match directives.

See https://pastebin.com/SuCG6dft  for the problem this solves.
There are 2 new config directives:

From Manpage:
```

     **PAMServiceName**
             Specifies the service identifier to be used for pluggable authentication modules
             (PAM).  If set to none, the sshd executable name (usually sshd) is used.  If set
             to name, authentication options can be configured in a matching file in
             /etc/pam.d/name.  The default is none.

     **PasswordPAMServiceName**
             Specifies the service identifier to be used for pluggable authentication modules
             (PAM) for PasswordAuthentication only. This is only used for the authentication
             (auth) PAM aspect. For account and session management, as well as
             ChallengeResponseAuthentication, the service name set in PAMServiceName is
             applied. This can be helpful to implement 2 factor authentication.  Example:

                   AuthenticationMethods "publickey,keyboard-interactive
                   password,keyboard-interactive"
                   PAMServiceName sshd_2factor
                   PasswordPAMServiceName sshd_password

             In this example, the challenge response authentication would ask the user for the
             second factor, for example an OATH token, while the first factor could be either
             provided by ssh-key or password. This requires two different PAM configurations to
             be used, in this example /etc/pam.d/sshd_2factor and /etc/pam.d/sshd_password. If
             set to none, the value of PAMServiceName is used.  The default is none.
```

Both new config options are allowed within **Match** directives, which allows very sophisticated setup, where different hosts can undergo completely different authentication paradigms.
If neither of the new options is set (or set to **none**) the behavior is as it used to, setting the pam service either to the program name or to the fixed override given with
./configure --with-pam-service=name

Implementation:
Instead of hardcoding the service name to SSHD_PAM_SERVICE, the pam handle is now initiated with a dynamic service name. Since this can change unexpectedly when used in Match directives, pam is now reinitialized every time pam_init() is called, even if the user is identical.

sshpam_auth_passwd() which implements PAM based PasswordAuthentication now uses its own separate PAM handle used for authentication only (the regular one is used for account and session management)

I'm looking forward to your feedback.